### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ---
-license: other
+license: bigscience-bloom-rail-1.0
 language:
 - ak
 - ar


### PR DESCRIPTION
This updates the license from `other` to `bigscience-bloom-rail-1.0` which is now a valid license on the HF Hub thanks to @julien-c.